### PR TITLE
Hint CPU install for PyTorch to reduce Docker image size and speedup build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.7.1
 transformers==4.41.2
 feedparser==6.0.11


### PR DESCRIPTION
Hint CPU install for PyTorch to reduce Docker image size and speedup build

Docker image size reduced from 6.63GB to 2.04GB. Also (on my setup) the build time reduced from 179s to 95s.